### PR TITLE
remove meta encoding

### DIFF
--- a/mailman-template.html
+++ b/mailman-template.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
-<!-- Version: 1.5 -->
+<!-- Version: 1.6 -->
 <html lang="en">
-<meta charset="utf-8">
   <head>
     <title><MM-List-Name> Mailing List - Wikimedia</title>
     <style>


### PR DESCRIPTION
UTF-8 is not supporting German, Korean, Finnish etc. (non-latin languages basically) so removing this in favour of file-based encoding of iso-8859-1.

@Thehelpfulone - this change is being made to all versions after this and put on Gerrit so, merge please :)
@quimgil - ditto above plus, commit access please? :)
